### PR TITLE
Update CONTRIBUTING.md - code of conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Code of Conduct
 
-All members of the project community must abide by the [Contributor Covenant, version 2.1](CODE_OF_CONDUCT.md).
+All members of the project community must abide by the [SAP Open Source Code of Conduct](https://github.com/SAP/.github/blob/main/CODE_OF_CONDUCT.md).
 Only by respecting each other we can develop a productive, collaborative community.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting [a project maintainer](.reuse/dep5).
 


### PR DESCRIPTION
Standard link to code of conduct was broken due to an outdated template.